### PR TITLE
line-join-line: fix a bug when joining lines

### DIFF
--- a/Standard-line/edit-protocol-implementation.lisp
+++ b/Standard-line/edit-protocol-implementation.lisp
@@ -242,10 +242,11 @@
 (defmethod cluffer-internal:line-join-line
     ((line1 closed-line) (line2 closed-line))
   (loop with length = (length (contents line1))
+          initially
+             (setf (contents line1)
+                   (concatenate 'vector (contents line1) (contents line2)))
 	for cursor in (cursors line2)
 	do (setf (line cursor) line1)
 	   (incf (cluffer:cursor-position cursor) length)
            (push cursor (cursors line1)))
-  (setf (contents line1)
-	(concatenate 'vector (contents line1) (contents line2)))
   nil)


### PR DESCRIPTION
When lines LINE1 and LINE2 were joined, then cursors from LINE2 were detached
and attached to LINE1 and position was incremented by the LINE1 length (so the
cursor position was the same relative to LINE2 elements). Then contents of LINE1
were concatenated with contents of LINE2.

Unless the cursor position is 0, increasing its position by LINE1 length signals
an error, because LINE1 is not yet concatenated with LINE2, so it has exactly
LENGTH elements (i.e not LENGTH1 + LENGTH2).

This commit addresses this issue by changing line1 contents before cursors are
moved from LINE2 to LINE1.