### PR TITLE
cursor: attach-cursor when the initarg line is supplied

### DIFF
--- a/Documentation/sec-line-edit-protocol.tex
+++ b/Documentation/sec-line-edit-protocol.tex
@@ -19,6 +19,11 @@ This is the base class for all cursors.
 The class \texttt{cursor} accepts this initarg which is the line to
 which the new cursor is to be attached.
 
+\Definitarg {:cursor-position}
+
+The class \texttt{cursor} accepts this initarg which is the position to
+which the new cursor is initialized on the attached line.
+
 \subsection{Operations on lines and cursors}
 
 \Defgeneric {cursor-position} {cursor}

--- a/Standard-line/classes.lisp
+++ b/Standard-line/classes.lisp
@@ -53,12 +53,17 @@
 (defclass cursor (cluffer:cursor)
   ((%line
     :initform nil
-    :initarg :line
     :accessor line
     :reader cluffer:line)
    (%cursor-position
-    :initarg :cursor-position
     :accessor cluffer:cursor-position)))
+
+(defmethod initialize-instance :after
+    ((cursor cluffer:cursor) &key line cursor-position)
+  (when line
+    (cluffer:attach-cursor cursor line))
+  (when cursor-position
+    (setf (cluffer:cursor-position cursor) cursor-position)))
 
 (defclass left-sticky-cursor (cursor)
   ())


### PR DESCRIPTION
Previously supplying the argument did associate the line with the cursor but it did not push the cursor to the line's maintained cursors. That have lead to an issue where line (when modified) did not update the cursor disregarding of whether it was left- or right- sticky.

Another issue was that the cursor-position was initialized when the initrarg :cursor-position was supplied disregarding of whether it was attached to the line or not, and disregarding of whether it did fit in the line or not - without signaling appropriate error.

The last issue was that the initarg :cursor-position was not documented.