### PR TITLE
Improvements and a safe PRINT-OBJECT method for cursors

### DIFF
--- a/Base/check-other-preconditions.lisp
+++ b/Base/check-other-preconditions.lisp
@@ -35,9 +35,10 @@
 
 (defmethod cluffer:attach-cursor :before
     ((cursor cluffer:cursor) (line cluffer:line) &optional position)
-  (declare (ignore position))
   (when (cluffer:cursor-attached-p cursor)
-    (error 'cluffer:cursor-attached)))
+    (error 'cluffer:cursor-attached))
+  (unless (or (null position) (<= 0 position (cluffer:item-count line)))
+    (error 'cluffer:end-of-line)))
 
 (defmethod cluffer:detach-cursor :before ((cursor cluffer:cursor))
   (unless (cluffer:cursor-attached-p cursor)

--- a/Base/edit-protocol.lisp
+++ b/Base/edit-protocol.lisp
@@ -419,7 +419,8 @@
 ;;; error of type DETACHED-CURSOR is signaled.
 ;;;
 ;;; If CURSOR1 and CURSOR2 are currently attached to lines that belong
-;;; to different buffers, a TODO error signaled.
+;;; to different buffers, an error of type CURSORS-ARE-NOT-COMPARABLE
+;;; is signaled.
 
 (defgeneric cluffer:cursor=/2 (cursor1 cursor2))
 
@@ -434,7 +435,8 @@
 ;;; error of type DETACHED-CURSOR is signaled.
 ;;;
 ;;; If CURSOR1 and CURSOR2 are currently attached to lines that belong
-;;; to different buffers, a TODO error signaled.
+;;; to different buffers, an error of type CURSORS-ARE-NOT-COMPARABLE
+;;; is signaled.
 
 (defgeneric cluffer:cursor</2 (cursor1 cursor2))
 

--- a/Base/edit-protocol.lisp
+++ b/Base/edit-protocol.lisp
@@ -440,17 +440,32 @@
 
 (defgeneric cluffer:cursor</2 (cursor1 cursor2))
 
-(defun cluffer:cursor< (cursor &rest more-cursors)
-  (or (null more-cursors)
-      (every #'cluffer:cursor</2 (list* cursor more-cursors) more-cursors)))
+(macrolet
+    ((define (name binary-predicate &key negatep)
+       (let ((reducer (if negatep 'notany 'every)))
+         `(progn
+            (defun ,name (cursor &rest more-cursors)
+              (or (null more-cursors)
+                  (,reducer (function ,binary-predicate)
+                            (list* cursor more-cursors) more-cursors)))
 
-(defun cluffer:cursor<= (cursor &rest more-cursors)
-  (or (null more-cursors)
-      (every #'cluffer:cursor<=/2 (list* cursor more-cursors) more-cursors)))
-
-(defun cluffer:cursor= (cursor &rest more-cursors)
-  (or (null more-cursors)
-      (every #'cluffer:cursor=/2 (list* cursor more-cursors) more-cursors)))
+            (define-compiler-macro ,name (cursor &rest more-cursors)
+              (if (null more-cursors)
+                  t
+                  (destructuring-bind (second-cursor &rest rest-cursors)
+                      more-cursors
+                    (let* ((binary `(,',binary-predicate ,cursor ,second-cursor))
+                           (pair   ,(if negatep
+                                        '`(not ,binary)
+                                        'binary)))
+                      (if (null rest-cursors)
+                          pair
+                          `(and ,pair (,',name ,@more-cursors)))))))))))
+  (define cluffer:cursor<  cluffer:cursor</2)
+  (define cluffer:cursor<= cluffer:cursor<=/2)
+  (define cluffer:cursor=  cluffer:cursor=/2)
+  (define cluffer:cursor>= cluffer:cursor</2  :negatep t)
+  (define cluffer:cursor>  cluffer:cursor<=/2 :negatep t))
 
 (defun cluffer:cursor/= (cursor &rest more-cursors)
   (cond ((null more-cursors)
@@ -466,11 +481,3 @@
                         when (cluffer:cursor=/2 cursor1 cursor2)
                           do (return-from outer nil))
                finally (return-from outer t)))))
-
-(defun cluffer:cursor>= (cursor &rest more-cursors)
-  (or (null more-cursors)
-      (notany #'cluffer:cursor</2 (list* cursor more-cursors) more-cursors)))
-
-(defun cluffer:cursor> (cursor &rest more-cursors)
-  (or (null more-cursors)
-      (notany #'cluffer:cursor<=/2 (list* cursor more-cursors) more-cursors)))

--- a/Standard-buffer/cluffer-standard-buffer.asd
+++ b/Standard-buffer/cluffer-standard-buffer.asd
@@ -9,4 +9,5 @@
    (:file "classes")
    (:file "edit-protocol-implementation")
    (:file "update-protocol-implementation")
-   (:file "internal-protocol-implementation")))
+   (:file "internal-protocol-implementation")
+   (:file "safe-print-object-for-cursor")))

--- a/Standard-buffer/safe-print-object-for-cursor.lisp
+++ b/Standard-buffer/safe-print-object-for-cursor.lisp
@@ -1,0 +1,67 @@
+(cl:in-package #:cluffer-standard-buffer)
+
+;;;; The purpose of the code in this file is to provide a
+;;;; `print-object' method for the `cluffer-standard-line:cursor'
+;;;; class that displays the line number of the line to which the
+;;;; cursor is attached without disturbing any data structures. The
+;;;; latter property is relevant when a `cluffer-standard-line:cursor'
+;;;; is used in the context of a `cluffer-standard-buffer:buffer'
+;;;; because the default implementation of `cluffer:line-number' for
+;;;; that combination can cause splay operations on the splay tree of
+;;;; the buffer.
+
+(defun safe-line-number (node)
+  ;; The number of lines "before" a node is the sum of
+  ;; 1) the number of lines in the left subtree of the node (therefore
+  ;;    RIGHT-CHILD-P is fixed at true for the initial
+  ;;    worklist item)
+  ;; 2) Certain line counts along the path from the node to the root:
+  ;;    for each ancestor, if the path reaches the ancestor through
+  ;;    its right child, then the number of lines in the left subtree
+  ;;    of that ancestor since all of those lines are "before" the
+  ;;    the right child.
+  ;; The following implementation is iterative as to not overflow the
+  ;; stack for large, poorly balanced trees.
+  (labels ((total-line-count (node)
+             (loop with count = 0
+                   with worklist = (list node)
+                   while worklist
+                   do (let* ((node  (pop worklist))
+                             (left  (bt:left node))
+                             (right (bt:right node)))
+                        (incf count)
+                        (unless (null left)
+                          (push left worklist))
+                        (unless (null right)
+                          (push right worklist)))
+                   finally (return count))))
+    (loop with count   = 0
+          with worklist   = (list (cons node t))
+          for  element = (pop worklist)
+          while element
+          do (destructuring-bind (node . right-child-p) element
+               (when right-child-p
+                 (incf count)
+                 (let ((left (bt:left node)))
+                   (unless (null left)
+                     (incf count (total-line-count left)))))
+               (let ((parent (bt:parent node)))
+                 (unless (null parent)
+                   (push (cons parent (eq node (bt:right parent)))
+                         worklist))))
+          finally (return (1- count)))))
+
+(defun maybe-safe-line-number (cursor)
+  (let* ((line (cluffer:line cursor))
+         (node (cluffer-internal:dock line)))
+    (typecase node
+      (node (safe-line-number node))
+      (t    (cluffer:line-number line)))))
+
+(defmethod print-object :around ((object cluffer:cursor) stream)
+  (if (cluffer:cursor-attached-p object)
+      (print-unreadable-object (object stream :type t :identity t)
+        (format stream "~:D:~:D"
+                (maybe-safe-line-number object)
+                (cluffer:cursor-position object)))
+      (call-next-method)))


### PR DESCRIPTION
Safe in the sense that, when the "standard buffer" implementation is used, printing a cursor does not cause splay operations in the underlying tree.